### PR TITLE
Fix NPE caused by empty directory

### DIFF
--- a/cache-library/src/main/java/com/vandalsoftware/io/IoUtils.java
+++ b/cache-library/src/main/java/com/vandalsoftware/io/IoUtils.java
@@ -99,11 +99,13 @@ public final class IoUtils {
         while (!dirs.isEmpty()) {
             final File d = dirs.remove();
             final File[] fs = d.listFiles();
-            for (File f : fs) {
-                if (f.isDirectory()) {
-                    dirs.add(f);
-                } else {
-                    deleteFileOrThrow(f);
+            if (fs != null) {
+                for (File f : fs) {
+                    if (f.isDirectory()) {
+                        dirs.add(f);
+                    } else {
+                        deleteFileOrThrow(f);
+                    }
                 }
             }
             emptyDirs.add(d);


### PR DESCRIPTION
If the file is a directory and it is already empty, the list of files
will be null. Check for null in this case and don't attempt to delete
anything and instead only add it to the list of emptyDirs.
